### PR TITLE
add: "bsky.app"で終わるURLの処理 #4

### DIFF
--- a/r2tokimeki.js
+++ b/r2tokimeki.js
@@ -8,49 +8,55 @@ for (const link_item of link_items) {
         // const a = url.match(/https:\/\/bsky.app\/(.*)\//);
         const a = /https:\/\/bsky.app\/(.*?)[\/\?]/.exec(url);
         // console.log(a);
-        switch (a[1]) {
-            case "profile":
-                // プロフィールページ・各投稿ページ・フィード
-            case "search":
-                // 検索
-                link_item.href = url.replace('https://bsky.app', 'https://tokimeki.blue');
-                break;
+        if (a) {
+            switch (a[1]) {
+                case "profile":
+                    // プロフィールページ・各投稿ページ・フィード
+                case "search":
+                    // 検索
+                    link_item.href = url.replace('https://bsky.app', 'https://tokimeki.blue');
+                    break;
 
-            case "hashtag":
-                // ハッシュタグ：TOKIMEKIは#付きの通常検索
-                link_item.href = url.replace('https://bsky.app/hashtag/', 'https://tokimeki.blue/search?q=%23');
-                break;
+                case "hashtag":
+                    // ハッシュタグ：TOKIMEKIは#付きの通常検索
+                    link_item.href = url.replace('https://bsky.app/hashtag/', 'https://tokimeki.blue/search?q=%23');
+                    break;
 
-            case "intent":
-                // 共有インテント
-                // 本家のインテントのパラメタはtextのみ。URLはテキスト末尾のスペース+https://の文字列から拾う
-                const b = /compose\?text=(.*)(?:%20|%0a|%0d|%09)(http.*)/i.exec(url);
-                let tkmk;
-                if (b) {
-                    tkmk = 'text=' + b[1].replace(/(%20|%0a|%0d|%09)*$/i, "");
-                    tkmk += '&url=' + b[2].trimEnd();
-                }
-                else {
-                    // こっちには来ないと思うけど念のため(テキストのみ・リンクのみの共有インテント)
-                    const s = url.replace(/https:\/\/bsky.app\/intent\/compose\?text=/, "");
-                    if (s.startsWith('http')) {
-                        tkmk = 'url=' + s;
+                case "intent":
+                    // 共有インテント
+                    // 本家のインテントのパラメタはtextのみ。URLはテキスト末尾のスペース+https://の文字列から拾う
+                    const b = /compose\?text=(.*)(?:%20|%0a|%0d|%09)(http.*)/i.exec(url);
+                    let tkmk;
+                    if (b) {
+                        tkmk = 'text=' + b[1].replace(/(%20|%0a|%0d|%09)*$/i, "");
+                        tkmk += '&url=' + b[2].trimEnd();
                     }
                     else {
-                        tkmk = 'text=' + s;
+                        // こっちには来ないと思うけど念のため(テキストのみ・リンクのみの共有インテント)
+                        const s = url.replace(/https:\/\/bsky.app\/intent\/compose\?text=/, "");
+                        if (s.startsWith('http')) {
+                            tkmk = 'url=' + s;
+                        }
+                        else {
+                            tkmk = 'text=' + s;
+                        }
                     }
-                }
-                link_item.href = 'https://tokimeki.blue/shared?' + tkmk;
-                break;
+                    link_item.href = 'https://tokimeki.blue/shared?' + tkmk;
+                    break;
 
-            // case "messages":
-            //     // DM (要らない気もする?)
-            //     link_item.href = url.replace('https://bsky.app/messages', 'https://tokimeki.blue/chat');
-            //     break;
-            //// チャットのURLを直で開いてもデータがロードされないので機能オフ
+                // case "messages":
+                //     // DM (要らない気もする?)
+                //     link_item.href = url.replace('https://bsky.app/messages', 'https://tokimeki.blue/chat');
+                //     break;
+                //// チャットのURLを直で開いてもデータがロードされないので機能オフ
 
-            default:
-                break;
+                default:
+                    break;
+            }
+        }
+        else {
+            // console.log("bsky.app top page or etc");
+            // nop
         }
         // console.log("bluesky link: " + link_item.href);
     }


### PR DESCRIPTION
トップページのみの場合に分岐処理用の正規表現にマッチしないため、後続処理の結果の配列アクセスに失敗するのを修正
fix #4 